### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Based on [github.com/lifthrasiir/qr.js](https://github.com/lifthrasiir/qr.js)
 ### jsDelivr
 
 ```
-https://cdn.jsdelivr.net/qrjs2/latest/qrjs2.min.js
+https://cdn.jsdelivr.net/npm/qrjs2@0.1.3/qrjs2.min.js
 ```
 
 ### unpkg


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/qrjs2.

Feel free to ping me if you have any questions regarding this change.