### PR TITLE
Remove npm from direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,7 @@
 		"type": "git",
 		"url": "git://github.com/englishextra/qrjs2.git"
 	},
-	"dependencies": {
-		"npm": "^7.3.0"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@babel/core": "^7.12.10",
 		"@babel/plugin-transform-arrow-functions": "^7.12.1",
@@ -69,6 +67,9 @@
 		"gulp-sourcemaps": "^3.0.0",
 		"gulp-strip-debug": "^3.0.0",
 		"gulp-uglify": "^3.0.2"
+	},
+	"engines": {
+		"npm": "7.x"
 	},
 	"scripts": {
 		"test": "gulp lint-libbundle-js"


### PR DESCRIPTION
### Pull Request

Fixes no referenced issue

Changes proposed:
* [ ]  Add
* [x] Fix
* [ ]  Remove
* [ ]  Update

Hello, I suggest this PR to remove the npm dependency from the package.json file.
Having it as a direct dependency adds npm package into the node_modules of any project installing qrjs2 via npm.
If you really need npm dependency to be local to the project, it could be into the devDependencies of the package.

I add the npm comptability within the engines definition into the package.